### PR TITLE
feat(curios): add optional curios compatibility for string lights

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,10 @@ repositories {
             includeGroup "dev.engine-room.flywheel"
         }
     }
+    maven {
+        name = "Curios"
+        url = "https://maven.theillusivec4.top/"
+    }
 }
 
 dependencies {
@@ -169,6 +173,10 @@ dependencies {
     implementation fg.deobf("net.createmod.ponder:Ponder-Forge-1.20.1:1.0.80")
     compileOnly fg.deobf("dev.engine-room.flywheel:flywheel-forge-api-1.20.1:1.0.4")
     runtimeOnly fg.deobf("maven.modrinth:create:1.20.1-6.0.6")
+
+    // Curios
+    compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
+    runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
 
     runtimeOnly fg.deobf("curse.maven:carry-on-274259:4882500")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ forge_version=47.3.0
 forge_version_range=[47,)
 loader_version_range=[47,)
 jei_version=15.20.0.105
+curios_version=5.9.1+1.20.1
 mapping_channel=parchment
 mapping_version=2023.08.20-1.20.1
 mod_id=kaleidoscope_tavern

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/client/render/entity/StringLightsLayer.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/client/render/entity/StringLightsLayer.java
@@ -1,6 +1,7 @@
 package com.github.ysbbbbbb.kaleidoscopetavern.client.render.entity;
 
 import com.github.ysbbbbbb.kaleidoscopetavern.item.StringLightsBlockItem;
+import com.github.ysbbbbbb.kaleidoscopetavern.compat.curios.CuriosCompat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import net.minecraft.client.Minecraft;
@@ -27,7 +28,7 @@ public class StringLightsLayer<T extends LivingEntity, M extends EntityModel<T>>
     public void render(PoseStack poseStack, MultiBufferSource buffer, int packedLight, T entity,
                        float limbSwing, float limbSwingAmount, float partialTick,
                        float ageInTicks, float netHeadYaw, float headPitch) {
-        ItemStack stack = entity.getItemBySlot(EquipmentSlot.CHEST);
+        ItemStack stack = getStringLightsStack(entity);
         if (stack.getItem() instanceof StringLightsBlockItem && this.getParentModel() instanceof HumanoidModel<?> humanoidModel) {
             poseStack.pushPose();
             humanoidModel.body.translateAndRotate(poseStack);
@@ -37,5 +38,13 @@ public class StringLightsLayer<T extends LivingEntity, M extends EntityModel<T>>
             this.itemRenderer.renderItem(entity, stack, ItemDisplayContext.HEAD, false, poseStack, buffer, packedLight);
             poseStack.popPose();
         }
+    }
+
+    private ItemStack getStringLightsStack(T entity) {
+        ItemStack chestStack = entity.getItemBySlot(EquipmentSlot.CHEST);
+        if (chestStack.getItem() instanceof StringLightsBlockItem) {
+            return chestStack;
+        }
+        return CuriosCompat.findStringLights(entity).orElse(ItemStack.EMPTY);
     }
 }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/compat/curios/CuriosCompat.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/compat/curios/CuriosCompat.java
@@ -1,0 +1,28 @@
+package com.github.ysbbbbbb.kaleidoscopetavern.compat.curios;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.ModList;
+
+import java.util.Optional;
+
+public class CuriosCompat {
+    private static final String ID = "curios";
+
+    public static void commonSetup() {
+        if (isLoaded()) {
+            CuriosCompatInner.registerStringLightsPredicate();
+        }
+    }
+
+    public static Optional<ItemStack> findStringLights(LivingEntity entity) {
+        if (isLoaded()) {
+            return CuriosCompatInner.findStringLights(entity);
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isLoaded() {
+        return ModList.get().isLoaded(ID);
+    }
+}

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/compat/curios/CuriosCompatInner.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/compat/curios/CuriosCompatInner.java
@@ -1,0 +1,53 @@
+package com.github.ysbbbbbb.kaleidoscopetavern.compat.curios;
+
+import com.github.ysbbbbbb.kaleidoscopetavern.KaleidoscopeTavern;
+import com.github.ysbbbbbb.kaleidoscopetavern.item.StringLightsBlockItem;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.util.LazyOptional;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
+import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+class CuriosCompatInner {
+    static void registerStringLightsPredicate() {
+        CuriosApi.registerCurioPredicate(
+                KaleidoscopeTavern.modLoc("string_lights"),
+                slotResult -> slotResult.stack().getItem() instanceof StringLightsBlockItem
+        );
+    }
+
+    static Optional<ItemStack> findStringLights(LivingEntity entity) {
+        LazyOptional<ICuriosItemHandler> inventory = CuriosApi.getCuriosInventory(entity);
+        return inventory.resolve().flatMap(handler -> handler.getCurios().values().stream()
+                .flatMap(stacksHandler -> findInStacksHandler(stacksHandler).stream())
+                .findFirst()
+                .map(ItemStack::copy));
+    }
+
+    private static Optional<ItemStack> findInStacksHandler(ICurioStacksHandler stacksHandler) {
+        IDynamicStackHandler stacks = stacksHandler.getStacks();
+        IDynamicStackHandler cosmeticStacks = stacksHandler.getCosmeticStacks();
+        return IntStream.range(0, stacks.getSlots())
+                .mapToObj(i -> getRenderableStack(stacksHandler, stacks, cosmeticStacks, i))
+                .filter(stack -> stack.getItem() instanceof StringLightsBlockItem)
+                .findFirst();
+    }
+
+    private static ItemStack getRenderableStack(ICurioStacksHandler stacksHandler, IDynamicStackHandler stacks,
+                                                IDynamicStackHandler cosmeticStacks, int index) {
+        ItemStack stack = cosmeticStacks.getStackInSlot(index);
+        if (stack.isEmpty() && isRenderable(stacksHandler, index)) {
+            stack = stacks.getStackInSlot(index);
+        }
+        return stack;
+    }
+
+    private static boolean isRenderable(ICurioStacksHandler stacksHandler, int index) {
+        return stacksHandler.getRenders().size() > index && stacksHandler.getRenders().get(index);
+    }
+}

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/init/register/CommonRegistry.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/init/register/CommonRegistry.java
@@ -3,6 +3,7 @@ package com.github.ysbbbbbb.kaleidoscopetavern.init.register;
 import com.github.ysbbbbbb.kaleidoscopetavern.KaleidoscopeTavern;
 import com.github.ysbbbbbb.kaleidoscopetavern.block.brew.BottleBlock;
 import com.github.ysbbbbbb.kaleidoscopetavern.block.dispenser.BottleBlockDispenseBehavior;
+import com.github.ysbbbbbb.kaleidoscopetavern.compat.curios.CuriosCompat;
 import com.github.ysbbbbbb.kaleidoscopetavern.game.tap.TapBehaviorManager;
 import com.github.ysbbbbbb.kaleidoscopetavern.game.tap.impl.*;
 import com.github.ysbbbbbb.kaleidoscopetavern.init.ModBlocks;
@@ -25,6 +26,7 @@ public class CommonRegistry {
         event.enqueueWork(CommonRegistry::addComposter);
         event.enqueueWork(CommonRegistry::addTapBehavior);
         event.enqueueWork(CommonRegistry::addDispenserBehavior);
+        event.enqueueWork(CuriosCompat::commonSetup);
     }
 
     private static void addTapBehavior() {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -22,3 +22,10 @@ mandatory = true
 versionRange = "${minecraft_version_range}"
 ordering = "NONE"
 side = "BOTH"
+
+[[dependencies."${mod_id}"]]
+modId = "curios"
+mandatory = false
+versionRange = "[5.9.1,)"
+ordering = "AFTER"
+side = "BOTH"

--- a/src/main/resources/data/curios/tags/items/charm.json
+++ b/src/main/resources/data/curios/tags/items/charm.json
@@ -1,0 +1,22 @@
+{
+  "replace": false,
+  "values": [
+    "kaleidoscope_tavern:string_lights_colorless",
+    "kaleidoscope_tavern:string_lights_white",
+    "kaleidoscope_tavern:string_lights_light_gray",
+    "kaleidoscope_tavern:string_lights_gray",
+    "kaleidoscope_tavern:string_lights_black",
+    "kaleidoscope_tavern:string_lights_brown",
+    "kaleidoscope_tavern:string_lights_red",
+    "kaleidoscope_tavern:string_lights_orange",
+    "kaleidoscope_tavern:string_lights_yellow",
+    "kaleidoscope_tavern:string_lights_lime",
+    "kaleidoscope_tavern:string_lights_green",
+    "kaleidoscope_tavern:string_lights_cyan",
+    "kaleidoscope_tavern:string_lights_light_blue",
+    "kaleidoscope_tavern:string_lights_blue",
+    "kaleidoscope_tavern:string_lights_purple",
+    "kaleidoscope_tavern:string_lights_magenta",
+    "kaleidoscope_tavern:string_lights_pink"
+  ]
+}


### PR DESCRIPTION
This PR adds optional Curios compatibility for string lights. Players can now equip a string light in Curios slots. (type: curio/charm)

本 PR 添加了一个非强制的 Curios API 模组联动。当安装 Curios API 模组后，玩家可以把小灯串挂在 **Charm** 槽位