### PR TITLE
fix: carignan instant health duration

### DIFF
--- a/src/generated/resources/data/kaleidoscope_tavern/datamap/drink_effect/carignan.json
+++ b/src/generated/resources/data/kaleidoscope_tavern/datamap/drink_effect/carignan.json
@@ -26,7 +26,7 @@
       },
       {
         "effect": "minecraft:instant_health",
-        "duration": 0,
+        "duration": 1,
         "amplifier": 0,
         "probability": 1.0
       }
@@ -40,7 +40,7 @@
       },
       {
         "effect": "minecraft:instant_health",
-        "duration": 0,
+        "duration": 1,
         "amplifier": 1,
         "probability": 1.0
       }
@@ -54,7 +54,7 @@
       },
       {
         "effect": "minecraft:instant_health",
-        "duration": 0,
+        "duration": 1,
         "amplifier": 2,
         "probability": 1.0
       }
@@ -68,7 +68,7 @@
       },
       {
         "effect": "minecraft:instant_health",
-        "duration": 0,
+        "duration": 1,
         "amplifier": 3,
         "probability": 1.0
       }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/datagen/datamap/DrinkEffectDataProvider.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopetavern/datagen/datamap/DrinkEffectDataProvider.java
@@ -88,10 +88,10 @@ public class DrinkEffectDataProvider implements DataProvider {
 
         // 佳丽私酿
         add(ModItems.CARIGNAN,
-                List.of(effect(MobEffects.HEAL, 0, 0)),
-                List.of(effect(MobEffects.HEAL, 0, 1)),
-                List.of(effect(MobEffects.HEAL, 0, 2)),
-                List.of(effect(MobEffects.HEAL, 0, 3))
+                List.of(effect(MobEffects.HEAL, 1, 0)),
+                List.of(effect(MobEffects.HEAL, 1, 1)),
+                List.of(effect(MobEffects.HEAL, 1, 2)),
+                List.of(effect(MobEffects.HEAL, 1, 3))
         );
 
         // 冰葡萄酒


### PR DESCRIPTION
Fixes https://github.com/KaleidoscopeMods/KaleidoscopeTavern/issues/34

The instant health effect requires at least a duration of 1 tick to give health back to the player. Currently, this is set as 0 resulting in no health to be given to players when they drink Carignan.

Tested locally and seems to resolve the issue.